### PR TITLE
Update PRIVMSG protocol based on RFC1459

### DIFF
--- a/src/server/packets/privmsg.packet.js
+++ b/src/server/packets/privmsg.packet.js
@@ -14,7 +14,7 @@ async function onPrivmsgCommand(conn, params, prefix) {
 }
 
 function privmsgPacket(conn, dest, nick, msg) {
-  conn.sendCommandPrefix("PRIVMSG", { nick }, dest, msg);
+  conn.sendCommandPrefix("PRIVMSG", { nick }, dest, ":" + msg);
 }
 
 module.exports = (server) => {


### PR DESCRIPTION
Last parameter with possible whitespaces must be prefixed by a punctuation colon.